### PR TITLE
Add `yo` as peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,13 +27,15 @@
     "cheerio": "~0.10.8"
   },
   "peerDependencies": {
-    "generator-mocha": "~0.1.1"
+    "generator-mocha": "~0.1.1",
+    "yo": ">=1.0.0-rc.1.1"
   },
   "devDependencies": {
     "mocha": "~1.9.0"
   },
   "engines": {
-    "node": ">=0.8.0"
+    "node": ">=0.8.0",
+    "npm": ">=1.2.10"
   },
   "licenses": [
     {


### PR DESCRIPTION
By adding `yo` as peer dependency, the user only has to `npm install -g generator-mobile` and is good to go.

I also added `npm >= 1.2.10` as engine requirement which shows a non-fatal warning in case the user is using an earlier version of npm, which doesn't support peer dependencies yet.

/ref https://github.com/yeoman/generator/issues/305
