### PR TITLE
Removed concat and uglify from build task

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -497,8 +497,10 @@ module.exports = function (grunt) {
         'requirejs',<% } %>
         'cssmin',<% if (responsiveImages) { %>
         'responsive_images:dev',<% } %>
-        'concat',
-        'uglify',
+        /* Since usemin does both concat and uglify tasks, there's no sense in
+         * calling commented out functions. */
+        /* 'concat',
+        'uglify', */
         'copy',
         'rev',
         'usemin'


### PR DESCRIPTION
Removed concat and uglify from build task since usemin does these two anyway and otherwise the generator will not build properly. These functions were already commented out above.
