### PR TITLE
Fix lint error when Bootstrap selected

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -388,7 +388,7 @@ AppGenerator.prototype.requirejs = function requirejs() {
     this.mainJsFile = [
       'require.config({',
       '    paths: {',
-      '        jquery: \'../bower_components/jquery/jquery\'' + boostrapPath,
+      '        jquery: \'../bower_components/jquery/jquery\'' + bootstrapPath,
       '    shim: {',
       '        bootstrap: {',
       '            deps: [\'jquery\'],',


### PR DESCRIPTION
When Bootstrap is selected the comma appears in a new line, breaking linter.
