### PR TITLE
Removed Google Chrome Frame reference

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -16,7 +16,7 @@
         <!--your page logic-->
 
         <!--[if lt IE 7]>
-            <p class="chromeframe">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> or <a href="http://www.google.com/chromeframe/?redirect=true">activate Google Chrome Frame</a> to improve your experience.</p>
+            <p class="chromeframe">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
         <![endif]-->
 
         <!-- Google Analytics: change UA-XXXXX-X to be your site's ID. -->


### PR DESCRIPTION
Chrome Frame is no longer supported (see http://www.google.com/chromeframe) and the URL only returns a 404 error.
