### PR TITLE
package.json will always use 2 spaces

### DIFF
--- a/app/templates/editorconfig
+++ b/app/templates/editorconfig
@@ -19,3 +19,7 @@ insert_final_newline = true
 
 [*.md]
 trim_trailing_whitespace = false
+
+[package.json]
+indent_size = 2
+indent_style = space


### PR DESCRIPTION
According to https://github.com/npm/npm/pull/3180#issuecomment-16336516 the `package.json` file will always use 2 spaces. This must be reflected in the `.editorconfig` file.
