### PR TITLE
Don't export `WSK_RELEASES_URL`

### DIFF
--- a/app/download.js
+++ b/app/download.js
@@ -49,5 +49,4 @@ function createDownloader(opts, cb) {
 
 
 module.exports = createDownloader;
-module.exports.WSK_RELEASES_URL = WSK_RELEASES_URL;
 module.exports.WSK_ZIP_URL = WSK_ZIP_URL;


### PR DESCRIPTION
Seems weird that we're exporting this as it didn't add any value and wasn't used anywhere?